### PR TITLE
Fix wrangler Dockerfile reference

### DIFF
--- a/cloudflare/Dockerfile
+++ b/cloudflare/Dockerfile
@@ -1,0 +1,28 @@
+# Keep this file in sync with /Dockerfile.
+# Cloudflare Wrangler validates `containers[].image` relative to the cloudflare/ project.
+# We set `image_build_context` to `..` so COPY paths still resolve from repo root.
+FROM node:20-alpine AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+FROM node:20-alpine AS backend-build
+RUN apk add --no-cache python3 make g++
+WORKDIR /app/backend
+COPY backend/package*.json ./
+RUN npm ci
+COPY backend/ ./
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=backend-build /app/backend/dist ./dist
+COPY --from=backend-build /app/backend/node_modules ./node_modules
+COPY --from=backend-build /app/backend/package.json ./
+COPY --from=frontend-build /app/frontend/dist ./public
+RUN mkdir -p /data/packages
+EXPOSE 8080
+ENV DATA_DIR=/data PORT=8080
+CMD ["node", "dist/index.js"]

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -31,6 +31,6 @@ npm run dev
 
 ## Notes
 
-- `wrangler.jsonc` points at `../Dockerfile` to reuse the existing app build.
+- `wrangler.jsonc` points at `./Dockerfile` and sets `image_build_context` to `..` so the container build still uses the repo-root app sources.
 - The worker routes all HTTP and WebSocket traffic to one named container instance (`main`) to keep app state consistent.
 - Container filesystem is ephemeral. Compiled packages may be lost when the container stops and restarts.

--- a/cloudflare/wrangler.jsonc
+++ b/cloudflare/wrangler.jsonc
@@ -6,7 +6,8 @@
   "containers": [
     {
       "class_name": "AssppContainer",
-      "image": "../Dockerfile",
+      "image": "./Dockerfile",
+      "image_build_context": "..",
       "instance_type": "standard-1",
       "max_instances": 1
     }


### PR DESCRIPTION
Fix Cloudflare one-click deploy Dockerfile path resolution

Cloudflare’s generated deploy repo only contains files under `cloudflare/`, so `wrangler.jsonc` with `image: "../Dockerfile"` fails validation (`invalid path to a Dockerfile`) during `wrangler deploy`.

This PR updates the Cloudflare target to use a local Dockerfile path and keeps the same root build context:

- change `containers[].image` from `../Dockerfile` to `./Dockerfile`
- add `containers[].image_build_context` as `..`
- add `cloudflare/Dockerfile` (same build stages as repo root Dockerfile)
- update `cloudflare/README.md` notes

Why this works:
- Wrangler validates image path relative to the Cloudflare project directory.
- Using `./Dockerfile` satisfies Wrangler path checks.
- `image_build_context: ".."` preserves access to `backend/` and `frontend/` for `COPY` during image build.

No runtime behavior changes intended; this only fixes deployment packaging/path resolution for Cloudflare one-click deployment.