### PR TITLE
fix: Deploy to Cloudflare

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,7 +8,7 @@
   "containers": [
     {
       "class_name": "AssppContainer",
-      "image": "ghcr.io/lakr233/assppweb:latest",
+      "image": "./Dockerfile",
       "instance_type": "standard-1",
       "max_instances": 1,
     },


### PR DESCRIPTION
### Error:

```
2026-02-24T07:57:26.748Z	Initializing build environment...
2026-02-24T07:57:28.862Z	Success: Finished initializing build environment
2026-02-24T07:57:29.194Z	Cloning repository...
2026-02-24T07:57:30.848Z	No build output detected to cache. Skipping.
2026-02-24T07:57:30.848Z	No dependencies detected to cache. Skipping.
2026-02-24T07:57:30.851Z	Detected the following tools from environment: 
2026-02-24T07:57:31.180Z	Executing user deploy command: npx wrangler deploy
2026-02-24T07:57:33.203Z	npm warn exec The following package was not found and will be installed: wrangler@4.68.0
2026-02-24T07:57:40.636Z	
2026-02-24T07:57:40.636Z	 ⛅️ wrangler 4.68.0
2026-02-24T07:57:40.636Z	───────────────────
2026-02-24T07:57:40.674Z	[custom build] Running: npm install --no-save --no-package-lock @cloudflare/containers@0.1.0
2026-02-24T07:57:41.668Z	[custom build] 
2026-02-24T07:57:41.668Z	[custom build] added 1 package in 829ms
2026-02-24T07:57:41.668Z	[custom build] 
2026-02-24T07:57:42.474Z	Total Upload: 32.91 KiB / gzip: 8.90 KiB
2026-02-24T07:57:43.990Z	Your Worker has access to the following bindings:
2026-02-24T07:57:43.990Z	Binding                                           Resource                  
2026-02-24T07:57:43.990Z	env.ASPP_CONTAINER (AssppContainer)               Durable Object            
2026-02-24T07:57:43.990Z	env.CONTAINER_INSTANCE_NAME ("main")              Environment Variable      
2026-02-24T07:57:43.990Z	
2026-02-24T07:57:43.991Z	The following containers are available:
2026-02-24T07:57:43.991Z	- assppweb-assppcontainer (ghcr.io/lakr233/assppweb:latest)
2026-02-24T07:57:43.991Z	
2026-02-24T07:57:43.991Z	Uploaded assppweb (1.86 sec)
2026-02-24T07:57:44.141Z	╭ Deploy a container application deploy changes to your application
2026-02-24T07:57:44.141Z	│
2026-02-24T07:57:44.727Z	│ Container application changes
2026-02-24T07:57:44.727Z	│
2026-02-24T07:57:44.727Z	├ NEW assppweb-assppcontainer
2026-02-24T07:57:44.727Z	│
2026-02-24T07:57:44.728Z	│   {
2026-02-24T07:57:44.728Z	│     "containers": [
2026-02-24T07:57:44.728Z	│       {
2026-02-24T07:57:44.728Z	│         "name": "assppweb-assppcontainer",
2026-02-24T07:57:44.728Z	│         "scheduling_policy": "default",
2026-02-24T07:57:44.728Z	│         "configuration": {
2026-02-24T07:57:44.728Z	│           "image": "ghcr.io/lakr233/assppweb:latest",
2026-02-24T07:57:44.728Z	│           "instance_type": "standard-1"
2026-02-24T07:57:44.728Z	│         },
2026-02-24T07:57:44.729Z	│         "instances": 0,
2026-02-24T07:57:44.729Z	│         "max_instances": 1,
2026-02-24T07:57:44.729Z	│         "constraints": {
2026-02-24T07:57:44.729Z	│           "tiers": [
2026-02-24T07:57:44.729Z	│             1,
2026-02-24T07:57:44.729Z	│             2
2026-02-24T07:57:44.729Z	│           ]
2026-02-24T07:57:44.729Z	│         },
2026-02-24T07:57:44.730Z	│         "durable_objects": {
2026-02-24T07:57:44.731Z	│           "namespace_id": "422ea4079e5248f187bd031637741f74"
2026-02-24T07:57:44.731Z	│         },
2026-02-24T07:57:44.731Z	│         "rollout_active_grace_period": 0
2026-02-24T07:57:44.731Z	│       }
2026-02-24T07:57:44.731Z	│     ]
2026-02-24T07:57:44.731Z	│   }
2026-02-24T07:57:44.731Z	│
2026-02-24T07:57:45.128Z	
2026-02-24T07:57:45.128Z	Cloudflare collects anonymous telemetry about your usage of Wrangler. Learn more at https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md
2026-02-24T07:57:45.129Z	
2026-02-24T07:57:45.208Z	✘ [ERROR] Error creating application due to a misconfiguration:
2026-02-24T07:57:45.208Z	
2026-02-24T07:57:45.208Z	  IMAGE_REGISTRY_NOT_CONFIGURED
2026-02-24T07:57:45.208Z	
2026-02-24T07:57:45.208Z	
2026-02-24T07:57:45.250Z	🪵  Logs were written to "/opt/buildhome/.config/.wrangler/logs/wrangler-2026-02-24_07-57-39_793.log"
2026-02-24T07:57:45.384Z	Failed: error occurred while running deploy command
```
https://developers.cloudflare.com/workers/wrangler/configuration/#containers
<img width="771" height="463" alt="image" src="https://github.com/user-attachments/assets/fbfe3806-540a-4dea-8e4e-cd62eaf38a70" />

### Solution:
Cloudflare Containers currently do not support pulling images directly from GHCR (ghcr.io). As a result, when creating a container application, the backend detects that the image registry type is either unsupported or not configured, and returns the error IMAGE_REGISTRY_NOT_CONFIGURED. To work around this, use a Dockerfile so that wrangler can automatically build and push the image to the Cloudflare Registry during deployment.
