### PR TITLE
Increase max download size to 8GB and timeout to 8 hours

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -4,8 +4,8 @@ export const config = {
   publicBaseUrl: process.env.PUBLIC_BASE_URL || "",
 };
 
-export const MAX_DOWNLOAD_SIZE = 4 * 1024 * 1024 * 1024; // 4 GB
-export const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+export const MAX_DOWNLOAD_SIZE = 8 * 1024 * 1024 * 1024; // 8 GB
+export const DOWNLOAD_TIMEOUT_MS = 8 * 60 * 60 * 1000; // 8 hours
 export const BAG_TIMEOUT_MS = 15_000; // 15 seconds
 export const BAG_MAX_BYTES = 1024 * 1024; // 1 MB
 export const MIN_ACCOUNT_HASH_LENGTH = 8;


### PR DESCRIPTION
## Summary
- Increased `MAX_DOWNLOAD_SIZE` from 4GB to 8GB to support large IPAs
- Increased `DOWNLOAD_TIMEOUT_MS` from 10 minutes to 8 hours to accommodate slow connections for large files

Closes #17

## Test plan
- [ ] Verify apps under 2GB still download successfully
- [ ] Verify apps over 2GB can complete download without hitting size or timeout limits