### PR TITLE
Fix settings endpoint header reflection vulnerability

### DIFF
--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -1,15 +1,14 @@
 import { Router, Request, Response } from "express";
+import { config } from "../config.js";
 
 const router = Router();
+const startedAt = Date.now();
 
-router.get("/settings", (req: Request, res: Response) => {
-  const hostname =
-    (req.headers["x-forwarded-host"] as string) ||
-    req.headers["host"] ||
-    "localhost";
+router.get("/settings", (_req: Request, res: Response) => {
   res.json({
-    hostname,
     version: "1.0.0",
+    dataDir: config.dataDir,
+    uptime: Math.floor((Date.now() - startedAt) / 1000),
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove raw `x-forwarded-host` / `host` header reflection from `/api/settings` response — prevents header injection / info leak
- Return server-side values only: `version`, `dataDir`, `uptime` — this also fixes the frontend Settings page which expected `dataDir` and `uptime` but was only receiving `hostname` (unused) and `version`
- Document security model in AGENTS.md: accountHash is public, Apple responses are trusted, browser same-origin is the credential boundary, backend must not reflect request headers

## Test plan

- [ ] Visit Settings page — verify version, data directory, and uptime display correctly
- [ ] `curl /api/settings` — confirm response contains no request headers (`hostname`, `x-forwarded-host`, etc.)
- [ ] Verify no regressions in install manifest generation (uses its own `getBaseUrl()` in `install.ts`, unaffected)