### PR TITLE
Feat: Add MAX_DOWNLOAD_MB environment variable to prevent container OOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ docker compose up -d
 | `UNSAFE_DANGEROUSLY_DISABLE_HTTPS_REDIRECT` | `false`         | Disable HTTPS redirect (see warning below)                                                  |
 | `AUTO_CLEANUP_DAYS`                         | `0`             | Automatically delete cached IPA files older than specified days (0 to disable)              |
 | `AUTO_CLEANUP_MAX_MB`                       | `0`             | Automatically delete oldest cached IPA files when size exceeds this MB limit (0 to disable) |
+| `MAX_DOWNLOAD_MB`                           | `0`             | Reject downloads exceeding this size in MB to prevent out-of-memory errors (0 to disable)   |
 
 **Reverse Proxy (Required for Install Apps on iOS)**
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -7,6 +7,9 @@ export const config = {
   // Auto-cleanup: 0 disables
   autoCleanupDays: parseInt(process.env.AUTO_CLEANUP_DAYS || "0", 10) || 0,
   autoCleanupMaxMB: parseInt(process.env.AUTO_CLEANUP_MAX_MB || "0", 10) || 0,
+  // NEW: Limit maximum download file size to prevent OOM errors (0 disables)
+  // 新增：限制最大下载文件大小，避免 OOM 错误（0为禁用）
+  maxDownloadMB: parseInt(process.env.MAX_DOWNLOAD_MB || "0", 10) || 0,
   // Build info (injected via Docker build args)
   buildCommit: process.env.BUILD_COMMIT || "unknown",
   buildDate: process.env.BUILD_DATE || "unknown",

--- a/backend/src/routes/downloads.ts
+++ b/backend/src/routes/downloads.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express";
+import { config } from "../config.js"; // NEW: Imported config for size validation
 import {
   createTask,
   getAllTasks,
@@ -40,6 +41,18 @@ router.post("/downloads", (req: Request, res: Response) => {
       error: err instanceof Error ? err.message : "Invalid download URL",
     });
     return;
+  }
+
+  // NEW: Validate download size limit on the backend if configured
+  // 新增：如果在后端配置了限制，则校验下载文件的大小
+  if (config.maxDownloadMB > 0 && software.fileSizeBytes) {
+    const sizeMB = parseInt(software.fileSizeBytes, 10) / (1024 * 1024);
+    if (sizeMB > config.maxDownloadMB) {
+      res.status(403).json({
+        error: `File size exceeds the maximum limit of ${config.maxDownloadMB}MB`,
+      });
+      return;
+    }
   }
 
   try {

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -15,6 +15,9 @@ router.get("/settings", (_req: Request, res: Response) => {
     disableHttpsRedirect: config.disableHttpsRedirect,
     autoCleanupDays: config.autoCleanupDays,
     autoCleanupMaxMB: config.autoCleanupMaxMB,
+    // NEW: Expose max download size limit to the frontend
+    // 新增：向前端暴露最大下载大小限制
+    maxDownloadMB: config.maxDownloadMB,
   });
 });
 

--- a/frontend/src/components/Settings/SettingsPage.tsx
+++ b/frontend/src/components/Settings/SettingsPage.tsx
@@ -18,6 +18,8 @@ interface ServerInfo {
   disableHttpsRedirect?: boolean;
   autoCleanupDays?: number;
   autoCleanupMaxMB?: number;
+  // 新增：在类型定义中添加 maxDownloadMB 以便在设置页接收和显示后端配置
+  maxDownloadMB?: number; 
 }
 
 const entityTypes = [
@@ -337,6 +339,16 @@ export default function SettingsPage() {
                     </dt>
                     <dd className="text-sm text-gray-900 dark:text-gray-200 font-mono">
                       {serverInfo.autoCleanupMaxMB ||
+                        t("settings.server.disabled")}
+                    </dd>
+                  </div>
+                  {/* 新增：在前端界面展示 MAX_DOWNLOAD_MB 配置状态 */}
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                      MAX_DOWNLOAD_MB
+                    </dt>
+                    <dd className="text-sm text-gray-900 dark:text-gray-200 font-mono">
+                      {serverInfo.maxDownloadMB ||
                         t("settings.server.disabled")}
                     </dd>
                   </div>

--- a/frontend/src/components/common/ToastContainer.tsx
+++ b/frontend/src/components/common/ToastContainer.tsx
@@ -105,11 +105,13 @@ export default function ToastContainer() {
                   {toast.title}
                 </h4>
               )}
-              <p
+              {/* NEW: Changed <p> to <div> to validly wrap potential ReactNode block elements */}
+              {/* 新增：将 <p> 改为 <div> 以合法地包裹可能存在的 ReactNode 块级元素 */}
+              <div
                 className={`text-sm font-medium text-gray-800 dark:text-gray-200 whitespace-pre-line break-words ${toast.title ? "leading-relaxed" : ""}`}
               >
                 {toast.message}
-              </p>
+              </div>
             </div>
 
             <div className="flex items-start pt-3 pr-3">

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -420,10 +420,15 @@
       "installStarted": "Installation Started",
       "shareAcquired": "Link Acquired",
       "downloadIpaStarted": "Downloading IPA",
-      "deleteSuccess": "Delete Success"
+      "deleteSuccess": "Delete Success",
+      "downloadLimit": "Size Limit Exceeded"
     },
     "msg": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}",
     "msgShare": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nYou can use AirDrop to share it with your friends.",
-    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nError: {{error}}"
+    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nError: {{error}}",
+    "downloadLimit": {
+      "line2": "App size <strong>{{size}}MB</strong> exceeds the maximum allowed size of <strong>{{limit}}MB</strong>.",
+      "line3": "Please contact the administrator or deploy your own instance to try again."
+    }
   }
 }

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -420,10 +420,15 @@
       "installStarted": "インストール開始",
       "shareAcquired": "リンク取得成功",
       "downloadIpaStarted": "IPA ダウンロード開始",
-      "deleteSuccess": "削除成功"
+      "deleteSuccess": "削除成功",
+      "downloadLimit": "サイズ制限超過"
     },
     "msg": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}",
     "msgShare": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nAirDropを使用して友達と共有できます。",
-    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nエラー: {{error}}"
+    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nエラー: {{error}}",
+    "downloadLimit": {
+      "line2": "アプリのサイズ <strong>{{size}}MB</strong> が最大ダウンロード制限の <strong>{{limit}}MB</strong> を超えています。",
+      "line3": "管理者に連絡するか、ご自身でサーバーを展開して再試行してください。"
+    }
   }
 }

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -420,10 +420,15 @@
       "installStarted": "설치 시작",
       "shareAcquired": "링크 획득",
       "downloadIpaStarted": "IPA 다운로드 시작",
-      "deleteSuccess": "삭제 성공"
+      "deleteSuccess": "삭제 성공",
+      "downloadLimit": "크기 제한 초과"
     },
     "msg": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}",
     "msgShare": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nAirDrop을 사용하여 친구와 공유할 수 있습니다.",
-    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n오류: {{error}}"
+    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n오류: {{error}}",
+    "downloadLimit": {
+      "line2": "앱 크기 <strong>{{size}}MB</strong>가 최대 허용 크기 <strong>{{limit}}MB</strong>를 초과했습니다.",
+      "line3": "관리자에게 문의하거나 자체 인스턴스를 배포하여 다시 시도하십시오."
+    }
   }
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -420,10 +420,15 @@
       "installStarted": "Начало установки",
       "shareAcquired": "Ссылка получена",
       "downloadIpaStarted": "Начало загрузки IPA",
-      "deleteSuccess": "Успешное удаление"
+      "deleteSuccess": "Успешное удаление",
+      "downloadLimit": "Превышен лимит размера"
     },
     "msg": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}",
     "msgShare": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nВы можете использовать AirDrop, чтобы поделиться ею с друзьями.",
-    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nОшибка: {{error}}"
+    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\nОшибка: {{error}}",
+    "downloadLimit": {
+      "line2": "Размер приложения <strong>{{size}}MB</strong> превышает максимально допустимый размер <strong>{{limit}}MB</strong>.",
+      "line3": "Пожалуйста, свяжитесь с администратором или разверните свой собственный сервер для повторной попытки."
+    }
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -420,10 +420,15 @@
       "installStarted": "开始安装",
       "shareAcquired": "链接已获取",
       "downloadIpaStarted": "开始下载 IPA",
-      "deleteSuccess": "删除成功"
+      "deleteSuccess": "删除成功",
+      "downloadLimit": "文件大小超限"
     },
     "msg": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}",
     "msgShare": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n您可以使用 Airdrop 分享给您的朋友。",
-    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n错误: {{error}}"
+    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n错误: {{error}}",
+    "downloadLimit": {
+      "line2": "该应用大小 <strong>{{size}}MB</strong> 超过管理员设置的最大可下载大小 <strong>{{limit}}MB</strong>",
+      "line3": "请联系管理员或自行部署后再尝试"
+    }
   }
 }

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -420,10 +420,15 @@
       "installStarted": "開始安裝",
       "shareAcquired": "連結已獲取",
       "downloadIpaStarted": "開始下載 IPA",
-      "deleteSuccess": "刪除成功"
+      "deleteSuccess": "刪除成功",
+      "downloadLimit": "檔案大小超限"
     },
     "msg": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}",
     "msgShare": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n您可以使用 Airdrop 分享給您的朋友。",
-    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n錯誤: {{error}}"
+    "msgFailed": "{{appName}}\n{{userName}} / {{appleId}} - {{country}}\n\n錯誤: {{error}}",
+    "downloadLimit": {
+      "line2": "該應用程式大小 <strong>{{size}}MB</strong> 超過管理員設定的最大可下載大小 <strong>{{limit}}MB</strong>",
+      "line3": "請聯絡管理員或自行部署後再嘗試"
+    }
   }
 }

--- a/frontend/src/store/toast.ts
+++ b/frontend/src/store/toast.ts
@@ -1,17 +1,20 @@
 import { create } from "zustand";
+import type { ReactNode } from "react"; // NEW: Added ReactNode import for custom JSX messages
 
 export type ToastType = "success" | "error" | "info";
 
 export interface Toast {
   id: string;
-  message: string;
+  // NEW: Allow ReactNode for formatted messages
+  // 新增：允许 ReactNode 以支持富文本和加粗等格式
+  message: string | ReactNode; 
   type: ToastType;
-  title?: string;
+  title?: string | ReactNode;
 }
 
 interface ToastStore {
   toasts: Toast[];
-  addToast: (message: string, type: ToastType, title?: string) => void;
+  addToast: (message: string | ReactNode, type: ToastType, title?: string | ReactNode) => void;
   removeToast: (id: string) => void;
 }
 


### PR DESCRIPTION
Motivation:
When deploying AssppWeb on free or resource-constrained container platforms, downloading excessively large IPA files can cause Out-Of-Memory (OOM) errors, forcing the container to crash and restart. This PR introduces a configurable maximum file size limit to gracefully reject oversized downloads and protect server stability.

Key Changes:

Backend Configuration:

Added the MAX_DOWNLOAD_MB environment variable (defaults to 0, meaning disabled).

Exposed this configuration to the frontend via the /api/settings endpoint.

Added server-side validation in the /api/downloads route to block requests where the fileSizeBytes exceeds the configured limit.

Frontend Validation & UI:

Upgraded useToastStore and ToastContainer to support ReactNode in the message and title fields, allowing for rich-text/formatted toast notifications.

Added a pre-flight check in useDownloadAction.ts. Before calling the Apple APIs, it fetches the server limit and aborts the process if the app size exceeds the threshold, displaying a rich-text warning. (Note: Used React.createElement instead of JSX to comply with Vite/esbuild restrictions on .ts files).

i18n Support:

Added localized translation strings for the size limit warning across all 6 supported languages (en-US, ja, ko, ru, zh-CN, zh-TW).

Documentation:

Documented the new environment variable in README.md.