### PR TITLE
Fix missing auth token when ACCESS_PASSWORD is enabled

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,7 +2,7 @@ import { getAccessToken } from "../components/Auth/PasswordGate";
 
 const BASE_URL = "";
 
-function authHeaders(): Record<string, string> {
+export function authHeaders(): Record<string, string> {
   const token = getAccessToken();
   return token ? { "X-Access-Token": token } : {};
 }

--- a/frontend/src/apple/bag.ts
+++ b/frontend/src/apple/bag.ts
@@ -1,3 +1,4 @@
+import { authHeaders } from "../api/client";
 import { parsePlist } from "./plist";
 
 export interface BagOutput {
@@ -12,7 +13,9 @@ export const defaultAuthURL =
 // The bag response is public data (Apple service URLs, no credentials).
 export async function fetchBag(deviceId: string): Promise<BagOutput> {
   try {
-    const resp = await fetch(`/api/bag?guid=${encodeURIComponent(deviceId)}`);
+    const resp = await fetch(`/api/bag?guid=${encodeURIComponent(deviceId)}`, {
+      headers: authHeaders(),
+    });
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({ error: resp.statusText }));
       console.warn(

--- a/frontend/src/components/Settings/SettingsPage.tsx
+++ b/frontend/src/components/Settings/SettingsPage.tsx
@@ -4,6 +4,7 @@ import PageContainer from "../Layout/PageContainer";
 import Modal from "../common/Modal";
 import { useAccountsStore } from "../../store/accounts";
 import { useToastStore } from "../../store/toast";
+import { apiGet } from "../../api/client";
 import { encryptData, decryptData } from "../../utils/crypto";
 import { countryCodeMap } from "../../apple/config";
 import type { Account } from "../../types";
@@ -62,8 +63,7 @@ export default function SettingsPage() {
   }, [entity]);
 
   useEffect(() => {
-    fetch("/api/settings")
-      .then((r) => (r.ok ? r.json() : null))
+    apiGet<ServerInfo>("/api/settings")
       .then(setServerInfo)
       .catch(() => setServerInfo(null));
   }, []);

--- a/frontend/src/components/Welcome/HomePage.tsx
+++ b/frontend/src/components/Welcome/HomePage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PageContainer from "../Layout/PageContainer";
 import { useAccounts } from "../../hooks/useAccounts";
+import { apiGet } from "../../api/client";
 import { accountHash } from "../../utils/account";
 
 interface Stats {
@@ -39,12 +40,8 @@ export default function HomePage() {
       });
 
       const [downloads, packages] = await Promise.all([
-        fetch(`/api/downloads?${params}`)
-          .then((r) => (r.ok ? r.json() : []))
-          .catch(() => []),
-        fetch(`/api/packages?${params}`)
-          .then((r) => (r.ok ? r.json() : []))
-          .catch(() => []),
+        apiGet<any[]>(`/api/downloads?${params}`).catch(() => []),
+        apiGet<any[]>(`/api/packages?${params}`).catch(() => []),
       ]);
 
       if (cancelled) return;


### PR DESCRIPTION
## Summary

- Adds `X-Access-Token` header to all frontend `/api/*` fetch calls that were missing it, fixing 401 errors when `ACCESS_PASSWORD` is set
- `/api/bag` (bag.ts) — used `authHeaders()` directly since the response is XML text, not JSON
- `/api/settings` (SettingsPage.tsx) — switched from raw `fetch` to `apiGet`
- `/api/downloads` and `/api/packages` (HomePage.tsx) — switched from raw `fetch` to `apiGet`
- Exported `authHeaders()` from `api/client.ts` for reuse in non-JSON endpoints

## Security review

Verified no other raw `fetch("/api/...")` calls remain in the frontend (except `/api/auth/*` in `PasswordGate.tsx`, which is intentionally unauthenticated and excluded by the backend middleware).

## Test plan

- [x] Frontend unit tests pass (64/64)
- [x] Backend unit tests pass (49/49)
- [ ] Manual: enable `ACCESS_PASSWORD`, verify account authentication works
- [ ] Manual: verify settings page loads server info
- [ ] Manual: verify home page shows correct download/package counts

Fixes #54