### PR TITLE
Fix false update detection from version string mismatch

### DIFF
--- a/frontend/src/components/Download/DownloadList.tsx
+++ b/frontend/src/components/Download/DownloadList.tsx
@@ -13,6 +13,7 @@ import { useToastStore } from '../../store/toast';
 import { lookupApp } from '../../api/search';
 import { storeIdToCountry } from '../../apple/config';
 import { getAccountContext } from '../../utils/toast';
+import { isNewerVersion } from '../../utils/version';
 import type { DownloadTask } from '../../types';
 
 type StatusFilter = 'all' | DownloadTask['status'];
@@ -107,7 +108,7 @@ export default function DownloadList() {
         const country = storeIdToCountry(account.store) ?? 'US';
         const latestApp = await lookupApp(task.software.bundleID, country);
 
-        if (latestApp && latestApp.version !== task.software.version) {
+        if (latestApp && isNewerVersion(latestApp.version, task.software.version)) {
           await startDownload(account, latestApp);
           await deleteDownload(task.id);
           count++;

--- a/frontend/src/components/Download/PackageDetail.tsx
+++ b/frontend/src/components/Download/PackageDetail.tsx
@@ -16,6 +16,7 @@ import { lookupApp } from '../../api/search';
 import { storeIdToCountry } from '../../apple/config';
 import { listVersions } from '../../apple/versionFinder';
 import { getAccountContext } from '../../utils/toast';
+import { isNewerVersion } from '../../utils/version';
 import type { Software } from '../../types';
 
 export default function PackageDetail() {
@@ -116,7 +117,7 @@ export default function PackageDetail() {
       const country = storeIdToCountry(account.store) ?? 'US';
       const app = await lookupApp(task.software.bundleID, country);
 
-      if (app && app.version !== task.software.version) {
+      if (app && isNewerVersion(app.version, task.software.version)) {
         setLatestApp(app);
         const result = await listVersions(account, app);
         setAvailableVersions(result.versions);

--- a/frontend/src/utils/version.ts
+++ b/frontend/src/utils/version.ts
@@ -1,0 +1,26 @@
+/**
+ * Compare two dot-separated version strings numerically.
+ * Missing segments are treated as 0 (e.g., "5" == "5.0" == "5.0.0").
+ *
+ * Returns:
+ *   positive if a > b
+ *   negative if a < b
+ *   0        if a == b
+ */
+export function compareVersions(a: string, b: string): number {
+  const partsA = a.split('.').map((s) => parseInt(s, 10) || 0);
+  const partsB = b.split('.').map((s) => parseInt(s, 10) || 0);
+  const len = Math.max(partsA.length, partsB.length);
+
+  for (let i = 0; i < len; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
+}
+
+/** Returns true when `latest` is strictly newer than `current`. */
+export function isNewerVersion(latest: string, current: string): boolean {
+  return compareVersions(latest, current) > 0;
+}

--- a/frontend/tests/utils/version.test.ts
+++ b/frontend/tests/utils/version.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { compareVersions, isNewerVersion } from '../../src/utils/version';
+
+describe('compareVersions', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareVersions('5.1', '5.1')).toBe(0);
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0);
+  });
+
+  it('treats missing segments as 0', () => {
+    expect(compareVersions('5', '5.0')).toBe(0);
+    expect(compareVersions('5', '5.0.0')).toBe(0);
+    expect(compareVersions('5.0', '5.0.0')).toBe(0);
+  });
+
+  it('returns positive when a > b', () => {
+    expect(compareVersions('5.1', '5')).toBeGreaterThan(0);
+    expect(compareVersions('5.1', '5.0')).toBeGreaterThan(0);
+    expect(compareVersions('6', '5.9.9')).toBeGreaterThan(0);
+    expect(compareVersions('1.2.4', '1.2.3')).toBeGreaterThan(0);
+  });
+
+  it('returns negative when a < b', () => {
+    expect(compareVersions('5', '5.1')).toBeLessThan(0);
+    expect(compareVersions('5.0', '5.1')).toBeLessThan(0);
+    expect(compareVersions('1.2.3', '1.2.4')).toBeLessThan(0);
+  });
+});
+
+describe('isNewerVersion', () => {
+  it('returns false when versions are equal', () => {
+    expect(isNewerVersion('5', '5')).toBe(false);
+    expect(isNewerVersion('5.1', '5.1')).toBe(false);
+  });
+
+  it('returns false when latest is older (issue #60 case)', () => {
+    // iTunes reports "5" but installed is "5.1" — no update
+    expect(isNewerVersion('5', '5.1')).toBe(false);
+  });
+
+  it('returns false when latest equals current with different padding', () => {
+    expect(isNewerVersion('5', '5.0')).toBe(false);
+    expect(isNewerVersion('5.0', '5.0.0')).toBe(false);
+  });
+
+  it('returns true when latest is genuinely newer', () => {
+    expect(isNewerVersion('5.2', '5.1')).toBe(true);
+    expect(isNewerVersion('6', '5.1')).toBe(true);
+    expect(isNewerVersion('6.0', '5.9.9')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Added `compareVersions()` / `isNewerVersion()` utility in `frontend/src/utils/version.ts`
- Replaced `!==` string inequality with `isNewerVersion()` in both update check locations:
  - `DownloadList.tsx` (check all updates)
  - `PackageDetail.tsx` (per-package check update)
- Added 8 unit tests covering equal versions, missing segments, and the exact issue #60 case

## Root cause

The stored version comes from `bundleShortVersionString` in Apple's download metadata (e.g., `"5.1"`), while the iTunes lookup API returns a marketing `version` field (e.g., `"5"`). The old check `latestApp.version !== task.software.version` treated any difference as an update, causing:

- `"5" !== "5.1"` → false positive: reported an "update" to version 5 when 5.1 was already installed
- Downloading the "update" produced the same 5.1 IPA, creating an infinite update loop

The new `isNewerVersion("5", "5.1")` correctly returns `false` since 5 < 5.1.

## Test plan

- [x] Frontend unit tests pass (72/72, including 8 new version comparison tests)
- [ ] Manual: download an app, check for updates — should report "no update" when versions match semantically
- [ ] Manual: verify genuine updates (newer iTunes version) are still detected

Fixes #60