### PR TITLE
Fix Wisp WebSocket auth failure behind Cloudflare

### DIFF
--- a/backend/src/services/wsProxy.ts
+++ b/backend/src/services/wsProxy.ts
@@ -22,7 +22,9 @@ export function setupWsProxy(server: HttpServer) {
     if (req.url?.startsWith("/wisp")) {
       if (accessPasswordHash) {
         const url = new URL(req.url, "http://localhost");
-        const token = url.searchParams.get("token") || "";
+        // Cloudflare URL normalization may append a trailing slash to the query
+        // string (e.g. ?token=abc/ instead of ?token=abc), so strip it.
+        const token = (url.searchParams.get("token") || "").replace(/\/+$/, "");
         if (!verifyAccessToken(token)) {
           socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
           socket.destroy();


### PR DESCRIPTION
## Summary
- Cloudflare URL normalization appends a trailing `/` to the query string, making the Wisp WebSocket access token include a spurious suffix (e.g. `?token=abc/` instead of `?token=abc`)
- The timing-safe comparison fails due to length mismatch, returning 401 and breaking all Apple protocol calls
- Strip trailing slashes from the token parameter before verification

## Test plan
- [ ] Deploy behind Cloudflare with `ACCESS_PASSWORD` set
- [ ] Verify Wisp WebSocket connects successfully (`wss://host/wisp/?token=...`)
- [ ] Verify Apple authentication works end-to-end