### PR TITLE
Add missing env vars to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ docker compose up -d
 | `AUTO_CLEANUP_DAYS`                         | `0`             | Automatically delete cached IPA files older than specified days (0 to disable)              |
 | `AUTO_CLEANUP_MAX_MB`                       | `0`             | Automatically delete oldest cached IPA files when size exceeds this MB limit (0 to disable) |
 | `MAX_DOWNLOAD_MB`                           | `0`             | Reject downloads exceeding this size in MB to prevent out-of-memory errors (0 to disable)   |
+| `DOWNLOAD_THREADS`                          | `8`             | Number of parallel threads for IPA downloads (1–32)                                         |
+| `ACCESS_PASSWORD`                           | _(none)_        | Require a password to access the web UI and API (empty to disable)                          |
 
 **Reverse Proxy (Required for Install Apps on iOS)**
 


### PR DESCRIPTION
## Summary
- Add `DOWNLOAD_THREADS` and `ACCESS_PASSWORD` to the environment variables table in the README

Closes #62