### PR TITLE
Port ApplePackage 1.2.7 protocol fixes (auth /fast/ + 5002 fallback)

### DIFF
--- a/frontend/src/apple/authenticate.ts
+++ b/frontend/src/apple/authenticate.ts
@@ -83,8 +83,9 @@ export async function authenticate(
       const podHeader = response.headers["pod"];
       const pod = podHeader || undefined;
 
-      // Handle redirect
-      if (response.status === 302) {
+      // Handle redirect. The native /fast auth host can answer with 301 as
+      // well as the usual 302, so follow the full set of redirect statuses.
+      if ([301, 302, 303, 307, 308].includes(response.status)) {
         const location = response.headers["location"];
         if (!location) {
           throw new Error(i18n.t("errors.auth.redirectLocation"));

--- a/frontend/src/apple/bag.ts
+++ b/frontend/src/apple/bag.ts
@@ -6,7 +6,30 @@ export interface BagOutput {
 }
 
 export const defaultAuthURL =
-  "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate";
+  "https://auth.itunes.apple.com/auth/v1/native/fast/";
+
+const NATIVE_AUTH_HOST = "auth.itunes.apple.com";
+
+// The bag advertises the native auth endpoint without the /fast/ sub-path that
+// the login flow requires; the no-trailing-slash variant 301s to an HTML page.
+// Legacy endpoints on other hosts pass through unchanged.
+export function normalizeAuthURL(rawURL: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawURL);
+  } catch {
+    return rawURL;
+  }
+  if (url.hostname !== NATIVE_AUTH_HOST) {
+    return rawURL;
+  }
+  let path = url.pathname.replace(/\/+$/, "");
+  if (!path.endsWith("/fast")) {
+    path += "/fast";
+  }
+  url.pathname = `${path}/`;
+  return url.toString();
+}
 
 // Fetches the bag via the backend proxy.
 // The backend fetches it using Node.js native HTTPS.
@@ -27,15 +50,12 @@ export async function fetchBag(deviceId: string): Promise<BagOutput> {
     const xml = await resp.text();
     const dict = parsePlist(xml) as Record<string, any>;
 
-    // authenticateAccount may be at top level or inside a urlBag dict
-    let authURL: string | undefined;
+    // authenticateAccount used to live inside the urlBag dict; newer bag
+    // responses move it to the plist root, so prefer the root and fall back.
     const urlBag = dict.urlBag as Record<string, any> | undefined;
-    if (urlBag) {
-      authURL = urlBag.authenticateAccount as string | undefined;
-    }
-    if (!authURL) {
-      authURL = dict.authenticateAccount as string | undefined;
-    }
+    const authURL =
+      (dict.authenticateAccount as string | undefined) ??
+      (urlBag?.authenticateAccount as string | undefined);
 
     if (!authURL) {
       console.warn(
@@ -44,7 +64,7 @@ export async function fetchBag(deviceId: string): Promise<BagOutput> {
       return { authURL: defaultAuthURL };
     }
 
-    return { authURL };
+    return { authURL: normalizeAuthURL(authURL) };
   } catch (error) {
     console.warn(
       `[Bag] Failed to fetch/parse bag, using default auth endpoint: ${

--- a/frontend/src/apple/config.ts
+++ b/frontend/src/apple/config.ts
@@ -151,6 +151,37 @@ export function storeAPIHost(pod?: string): string {
   return "p25-buy.itunes.apple.com";
 }
 
+// The volumeStore endpoint intermittently rejects requests with failureType
+// 5002. The legacy redownload dispatch endpoint serves the same payload and is
+// used as a fallback. The two endpoints name the external version id
+// differently in the request payload.
+export const RETRYABLE_FAILURE_TYPE = "5002";
+
+export interface StoreDownloadEndpoint {
+  host: string;
+  path: string;
+  externalVersionIdKey: string;
+}
+
+export function volumeStoreEndpoint(
+  pod: string | undefined,
+  deviceId: string,
+): StoreDownloadEndpoint {
+  return {
+    host: storeAPIHost(pod),
+    path: `/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid=${deviceId}`,
+    externalVersionIdKey: "externalVersionId",
+  };
+}
+
+export function redownloadEndpoint(deviceId: string): StoreDownloadEndpoint {
+  return {
+    host: "downloaddispatch.itunes.apple.com",
+    path: `/r/redownload?guid=${deviceId}`,
+    externalVersionIdKey: "appExtVrsId",
+  };
+}
+
 export function purchaseAPIHost(pod?: string): string {
   if (pod) return `p${pod}-buy.itunes.apple.com`;
   return "buy.itunes.apple.com";

--- a/frontend/src/apple/download.ts
+++ b/frontend/src/apple/download.ts
@@ -2,7 +2,11 @@ import type { Account, Software, DownloadOutput, Sinf } from "../types";
 import { appleRequest } from "./request";
 import { buildPlist, parsePlist } from "./plist";
 import { extractAndMergeCookies } from "./cookies";
-import { storeAPIHost } from "./config";
+import {
+  RETRYABLE_FAILURE_TYPE,
+  redownloadEndpoint,
+  volumeStoreEndpoint,
+} from "./config";
 import i18n from "../i18n";
 
 export class DownloadError extends Error {
@@ -22,8 +26,10 @@ export async function getDownloadInfo(
 ): Promise<{ output: DownloadOutput; updatedCookies: typeof account.cookies }> {
   const deviceId = account.deviceIdentifier;
 
-  let requestHost = storeAPIHost(account.pod);
-  let requestPath = `/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid=${deviceId}`;
+  let endpoint = volumeStoreEndpoint(account.pod, deviceId);
+  let requestHost = endpoint.host;
+  let requestPath = endpoint.path;
+  let triedRedownload = false;
   let cookies = [...account.cookies];
   let redirectAttempt = 0;
 
@@ -35,7 +41,7 @@ export async function getDownloadInfo(
     };
 
     if (externalVersionId) {
-      payload.externalVersionId = externalVersionId;
+      payload[endpoint.externalVersionIdKey] = externalVersionId;
     }
 
     const plistBody = buildPlist(payload);
@@ -73,6 +79,18 @@ export async function getDownloadInfo(
 
     if (dict.failureType) {
       const failureType = String(dict.failureType);
+
+      // volumeStore intermittently returns 5002; retry once via the
+      // redownload dispatch endpoint, which serves the same payload.
+      if (failureType === RETRYABLE_FAILURE_TYPE && !triedRedownload) {
+        triedRedownload = true;
+        endpoint = redownloadEndpoint(deviceId);
+        requestHost = endpoint.host;
+        requestPath = endpoint.path;
+        redirectAttempt = 0;
+        continue;
+      }
+
       const customerMessage = dict.customerMessage as string | undefined;
       switch (failureType) {
         case "2034":

--- a/frontend/src/apple/versionFinder.ts
+++ b/frontend/src/apple/versionFinder.ts
@@ -2,7 +2,11 @@ import type { Account, Software } from "../types";
 import { appleRequest } from "./request";
 import { buildPlist, parsePlist } from "./plist";
 import { extractAndMergeCookies } from "./cookies";
-import { storeAPIHost } from "./config";
+import {
+  RETRYABLE_FAILURE_TYPE,
+  redownloadEndpoint,
+  volumeStoreEndpoint,
+} from "./config";
 
 export async function listVersions(
   account: Account,
@@ -10,8 +14,10 @@ export async function listVersions(
 ): Promise<{ versions: string[]; updatedCookies: typeof account.cookies }> {
   const deviceId = account.deviceIdentifier;
 
-  let requestHost = storeAPIHost(account.pod);
-  let requestPath = `/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid=${deviceId}`;
+  let endpoint = volumeStoreEndpoint(account.pod, deviceId);
+  let requestHost = endpoint.host;
+  let requestPath = endpoint.path;
+  let triedRedownload = false;
   let cookies = [...account.cookies];
   let redirectAttempt = 0;
 
@@ -59,6 +65,18 @@ export async function listVersions(
     if (!songList || songList.length === 0) {
       if (dict.failureType) {
         const failureType = String(dict.failureType);
+
+        // volumeStore intermittently returns 5002; retry once via the
+        // redownload dispatch endpoint, which serves the same payload.
+        if (failureType === RETRYABLE_FAILURE_TYPE && !triedRedownload) {
+          triedRedownload = true;
+          endpoint = redownloadEndpoint(deviceId);
+          requestHost = endpoint.host;
+          requestPath = endpoint.path;
+          redirectAttempt = 0;
+          continue;
+        }
+
         switch (failureType) {
           case "2034":
             throw new Error("Password token is expired");

--- a/frontend/src/apple/versionLookup.ts
+++ b/frontend/src/apple/versionLookup.ts
@@ -2,7 +2,11 @@ import type { Account, Software, VersionMetadata } from "../types";
 import { appleRequest } from "./request";
 import { buildPlist, parsePlist } from "./plist";
 import { extractAndMergeCookies } from "./cookies";
-import { storeAPIHost } from "./config";
+import {
+  RETRYABLE_FAILURE_TYPE,
+  redownloadEndpoint,
+  volumeStoreEndpoint,
+} from "./config";
 
 export async function getVersionMetadata(
   account: Account,
@@ -14,8 +18,10 @@ export async function getVersionMetadata(
 }> {
   const deviceId = account.deviceIdentifier;
 
-  let requestHost = storeAPIHost(account.pod);
-  let requestPath = `/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid=${deviceId}`;
+  let endpoint = volumeStoreEndpoint(account.pod, deviceId);
+  let requestHost = endpoint.host;
+  let requestPath = endpoint.path;
+  let triedRedownload = false;
   let cookies = [...account.cookies];
   let redirectAttempt = 0;
 
@@ -24,7 +30,7 @@ export async function getVersionMetadata(
       creditDisplay: "",
       guid: deviceId,
       salableAdamId: app.id,
-      externalVersionId: versionId,
+      [endpoint.externalVersionIdKey]: versionId,
     };
 
     const plistBody = buildPlist(payload);
@@ -59,6 +65,20 @@ export async function getVersionMetadata(
     }
 
     const dict = parsePlist(response.body) as Record<string, any>;
+
+    // volumeStore intermittently returns 5002; retry once via the redownload
+    // dispatch endpoint, which serves the same payload.
+    if (
+      String(dict.failureType ?? "") === RETRYABLE_FAILURE_TYPE &&
+      !triedRedownload
+    ) {
+      triedRedownload = true;
+      endpoint = redownloadEndpoint(deviceId);
+      requestHost = endpoint.host;
+      requestPath = endpoint.path;
+      redirectAttempt = 0;
+      continue;
+    }
 
     const songList = dict.songList as Record<string, any>[] | undefined;
     if (!songList || songList.length === 0) {

--- a/frontend/tests/apple/bag.test.ts
+++ b/frontend/tests/apple/bag.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildPlist } from "../../src/apple/plist";
-import { defaultAuthURL, fetchBag } from "../../src/apple/bag";
+import {
+  defaultAuthURL,
+  fetchBag,
+  normalizeAuthURL,
+} from "../../src/apple/bag";
 
 describe("apple/bag", () => {
   beforeEach(() => {
@@ -26,6 +30,25 @@ describe("apple/bag", () => {
 
     expect(result.authURL).toBe(
       "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate",
+    );
+  });
+
+  it("normalizes a native auth endpoint at the plist root to the /fast/ path", async () => {
+    const xml = buildPlist({
+      authenticateAccount: "https://auth.itunes.apple.com/auth/v1/native",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => xml,
+      }),
+    );
+
+    const result = await fetchBag("aabbccddeeff");
+
+    expect(result.authURL).toBe(
+      "https://auth.itunes.apple.com/auth/v1/native/fast/",
     );
   });
 
@@ -62,5 +85,31 @@ describe("apple/bag", () => {
     const result = await fetchBag("aabbccddeeff");
 
     expect(result.authURL).toBe(defaultAuthURL);
+  });
+
+  describe("normalizeAuthURL", () => {
+    it("appends /fast/ to a bare native auth endpoint", () => {
+      expect(
+        normalizeAuthURL("https://auth.itunes.apple.com/auth/v1/native"),
+      ).toBe("https://auth.itunes.apple.com/auth/v1/native/fast/");
+    });
+
+    it("adds the trailing slash when /fast is already present", () => {
+      expect(
+        normalizeAuthURL("https://auth.itunes.apple.com/auth/v1/native/fast"),
+      ).toBe("https://auth.itunes.apple.com/auth/v1/native/fast/");
+    });
+
+    it("is idempotent on an already-normalized endpoint", () => {
+      expect(
+        normalizeAuthURL("https://auth.itunes.apple.com/auth/v1/native/fast/"),
+      ).toBe("https://auth.itunes.apple.com/auth/v1/native/fast/");
+    });
+
+    it("leaves legacy endpoints on other hosts unchanged", () => {
+      const legacy =
+        "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate";
+      expect(normalizeAuthURL(legacy)).toBe(legacy);
+    });
   });
 });

--- a/frontend/tests/apple/config.test.ts
+++ b/frontend/tests/apple/config.test.ts
@@ -7,6 +7,9 @@ import {
   purchaseAPIHost,
   countryToStoreId,
   storeIdToCountry,
+  RETRYABLE_FAILURE_TYPE,
+  volumeStoreEndpoint,
+  redownloadEndpoint,
 } from "../../src/apple/config";
 
 describe("apple/config", () => {
@@ -123,6 +126,28 @@ describe("apple/config", () => {
 
     it("should return undefined for unknown store ID", () => {
       expect(storeIdToCountry("999999")).toBeUndefined();
+    });
+  });
+
+  describe("store download endpoints", () => {
+    it("volumeStore targets MZFinance with the externalVersionId key", () => {
+      const ep = volumeStoreEndpoint("42", "aabbccddeeff");
+      expect(ep.host).toBe("p42-buy.itunes.apple.com");
+      expect(ep.path).toBe(
+        "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid=aabbccddeeff",
+      );
+      expect(ep.externalVersionIdKey).toBe("externalVersionId");
+    });
+
+    it("redownload targets downloaddispatch with the appExtVrsId key", () => {
+      const ep = redownloadEndpoint("aabbccddeeff");
+      expect(ep.host).toBe("downloaddispatch.itunes.apple.com");
+      expect(ep.path).toBe("/r/redownload?guid=aabbccddeeff");
+      expect(ep.externalVersionIdKey).toBe("appExtVrsId");
+    });
+
+    it("exposes the retryable failure type used for fallback", () => {
+      expect(RETRYABLE_FAILURE_TYPE).toBe("5002");
     });
   });
 });


### PR DESCRIPTION
Mirrors the fixes shipped in ApplePackage 1.2.7 so the web client logs in and downloads against Apple's current infrastructure.

- **bag**: default to and normalize the native auth endpoint `auth.itunes.apple.com/auth/v1/native/fast/`; the bare `/fast` variant 301s to an HTML page. Read `authenticateAccount` from the plist root with the `urlBag` dict as fallback.
- **authenticate**: follow 301/303/307/308 redirects, not only 302 — the native auth host answers with 301.
- **download / versionFinder / versionLookup**: when volumeStore returns failureType 5002, retry once via the redownload dispatch endpoint (`downloaddispatch.itunes.apple.com/r/redownload`, `appExtVrsId` key).
- **config**: shared volumeStore/redownload endpoint helpers.

Adds regression tests for auth normalization and the endpoint helpers.

Verified locally: `npm run build` and `npm test` (80 passing) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)