### PR TITLE
Allow downloaddispatch.itunes.apple.com through the Wisp proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ The Wisp server validates target hosts via `hostname_whitelist` in `backend/src/
 - `buy.itunes.apple.com` — purchase endpoint
 - `init.itunes.apple.com` — bag endpoint
 - `/^p\d+-buy\.itunes\.apple\.com$/` — pod-based hosts
+- `downloaddispatch.itunes.apple.com` — redownload dispatch endpoint (failureType 5002 fallback)
 - Port restricted to `443` only
 - Direct IP targets blocked (`allow_direct_ip = false`)
 - Loopback IP targets blocked (`allow_loopback_ips = false`)

--- a/backend/src/services/wsProxy.ts
+++ b/backend/src/services/wsProxy.ts
@@ -2,12 +2,13 @@ import { Server as HttpServer } from "http";
 import { server as wisp } from "@mercuryworkshop/wisp-js/server";
 import { accessPasswordHash, verifyAccessToken } from "../config.js";
 
-// Allow only Apple hosts required by bag/auth/purchase/version flows.
+// Allow only Apple hosts required by bag/auth/purchase/version/download flows.
 wisp.options.hostname_whitelist = [
   /^auth\.itunes\.apple\.com$/,
   /^buy\.itunes\.apple\.com$/,
   /^init\.itunes\.apple\.com$/,
   /^p\d+-buy\.itunes\.apple\.com$/,
+  /^downloaddispatch\.itunes\.apple\.com$/,
 ];
 wisp.options.port_whitelist = [443];
 wisp.options.allow_direct_ip = false;


### PR DESCRIPTION
## What

`downloaddispatch.itunes.apple.com` is missing from the Wisp `hostname_whitelist`.

## Why it matters

17359ec added a failureType 5002 fallback that points the download, version lookup and version finder flows at that host:

- `frontend/src/apple/config.ts` — `redownloadEndpoint()`
- `frontend/src/apple/download.ts:87`
- `frontend/src/apple/versionFinder.ts:76`
- `frontend/src/apple/versionLookup.ts:76`

but `backend/src/services/wsProxy.ts` was not touched in that commit, so every fallback attempt is closed at the transport layer with `HostBlocked` (`wisp-js` `src/server/filter.mjs`) before it reaches Apple. It never surfaces as an HTTP status — the stream is simply closed — which makes it awkward to spot from the client side.

## This is not a rare path

Against a live account on pod 18, the primary `volumeStoreDownloadProduct` endpoint returned failureType 5002 on all four probes, while the redownload dispatch endpoint succeeded on all eight. For that account the fallback is the only working route, so downloads fail entirely without this.

## Change

One entry in the allowlist, plus the matching line in AGENTS.md so the documented list still matches the code. Port stays restricted to 443 and every other control is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)